### PR TITLE
Add `lenient` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ export interface Options {
 
 	@example
 	```
+    import isUrl from 'is-url-superb';
+
 	isUrl('www.example.com');
 	//=> false
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface Options {
 	/**
-	Wether it should automatically prepend `https://` in case the input has no protocol defined.
+	Whether URLs without a protocol should be allowed.
 
 	@default false
 
@@ -31,12 +31,9 @@ isUrl('https://sindresorhus.com');
 isUrl('unicorn');
 //=> false
 
-// Enable lenient mode to automatically prepend `https://` to the input in case it has no protocol defined.
+// Use the lenient option to allow URLs without a protocol.
 isUrl('unicorn', {lenient: true});
 //=> true
 ```
 */
-export default function isUrl(
-	url: string,
-	options?: Options
-): boolean;
+export default function isUrl(url: string, options?: Options): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export interface Options {
 	isUrl('www.example.com');
 	//=> false
 
-	isUrl('www.example.com', { lenient: true });
+	isUrl('www.example.com', {lenient: true});
 	//=> true
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,21 @@
+export interface Options {
+	/**
+	Wether it should automatically prepend `https://` in case the input has no protocol defined.
+
+	@default false
+
+	@example
+	```
+	isUrl('www.example.com');
+	//=> false
+
+	isUrl('www.example.com', { lenient: true });
+	//=> true
+	```
+	*/
+	readonly lenient?: boolean;
+}
+
 /**
 Check if a string is a URL.
 
@@ -18,20 +36,5 @@ isUrl('unicorn', {lenient: true});
 */
 export default function isUrl(
 	url: string,
-	options?: {
-		/**
-		 * Wether it should automatically prepend `https://` in case the input has no protocol defined.
-		 *
-		 * @example
-		 * isUrl('www.example.com');
-		 * //=> false
-		 *
-		 * isUrl('www.example.com', { lenient: true });
-		 * //=> true
-		 *
-		 * @default
-		 * false
-		 */
-		lenient: boolean;
-	}
+	options?: Options
 ): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,17 @@
 export interface Options {
 	/**
-	Whether URLs without a protocol should be allowed.
+	Allow URLs without a protocol.
 
 	@default false
 
 	@example
 	```
-    import isUrl from 'is-url-superb';
+	import isUrl from 'is-url-superb';
 
-	isUrl('www.example.com');
+	isUrl('example.com');
 	//=> false
 
-	isUrl('www.example.com', {lenient: true});
+	isUrl('example.com', {lenient: true});
 	//=> true
 	```
 	*/
@@ -30,10 +30,6 @@ isUrl('https://sindresorhus.com');
 
 isUrl('unicorn');
 //=> false
-
-// Use the lenient option to allow URLs without a protocol.
-isUrl('unicorn', {lenient: true});
-//=> true
 ```
 */
 export default function isUrl(url: string, options?: Options): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,11 +8,30 @@ import isUrl from 'is-url-superb';
 isUrl('https://sindresorhus.com');
 //=> true
 
-isUrl('//sindresorhus.com');
-//=> true
-
 isUrl('unicorn');
 //=> false
+
+// Enable lenient mode to automatically prepend `https://` to the input in case it has no protocol defined.
+isUrl('unicorn', {lenient: true});
+//=> true
 ```
 */
-export default function isUrl(url: string): boolean;
+export default function isUrl(
+	url: string,
+	options?: {
+		/**
+		 * Wether it should automatically prepend `https://` in case the input has no protocol defined.
+		 *
+		 * @example
+		 * isUrl('www.example.com');
+		 * //=> false
+		 *
+		 * isUrl('www.example.com', { lenient: true });
+		 * //=> true
+		 *
+		 * @default
+		 * false
+		 */
+		lenient: boolean;
+	}
+): boolean;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export default function isUrl(string) {
+export default function isUrl(string, {lenient = false} = {}) {
 	if (typeof string !== 'string') {
 		throw new TypeError('Expected a string');
 	}
@@ -12,6 +12,10 @@ export default function isUrl(string) {
 		new URL(string); // eslint-disable-line no-new
 		return true;
 	} catch {
+		if (lenient) {
+			return isUrl(`https://${string}`);
+		}
+
 		return false;
 	}
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,3 +2,5 @@ import {expectType} from 'tsd';
 import isUrl from './index.js';
 
 expectType<boolean>(isUrl('https://sindresorhus.com'));
+expectType<boolean>(isUrl('https://sindresorhus.com', {lenient: false}));
+expectType<boolean>(isUrl('https://sindresorhus.com', {lenient: true}));

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ isUrl('https://sindresorhus.com');
 isUrl('unicorn');
 //=> false
 
-// Enable lenient mode to automatically prepend `https://` to the input in case it has no protocol defined.
+// Use the lenient option to allow URLs without a protocol.
 isUrl('unicorn', {lenient: true});
 //=> true
 ```
@@ -37,7 +37,7 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Wether it should automatically prepend `https://` in case the input has no protocol defined.
+Whether URLs without a protocol should be allowed.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,21 @@ isUrl('unicorn', {lenient: true});
 //=> true
 ```
 
+## API
+
+### isUrl(string, options?)
+
+#### options
+
+Type: `object`
+
+##### lenient
+
+Type: `boolean`\
+Default: `false`
+
+Wether it should automatically prepend `https://` in case the input has no protocol defined.
+
 ## Related
 
 - [is](https://github.com/sindresorhus/is) - Type check values

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ isUrl('https://sindresorhus.com');
 
 isUrl('unicorn');
 //=> false
+
+// Enable lenient mode to automatically prepend `https://` to the input in case it has no protocol defined.
+isUrl('unicorn', {lenient: true});
+//=> true
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,6 @@ isUrl('https://sindresorhus.com');
 
 isUrl('unicorn');
 //=> false
-
-// Use the lenient option to allow URLs without a protocol.
-isUrl('unicorn', {lenient: true});
-//=> true
 ```
 
 ## API
@@ -37,7 +33,17 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Whether URLs without a protocol should be allowed.
+Allow URLs without a protocol.
+
+```js
+import isUrl from 'is-url-superb';
+
+isUrl('example.com');
+//=> false
+
+isUrl('example.com', {lenient: true});
+//=> true
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -7,4 +7,32 @@ test('main', t => {
 	t.false(isUrl('abc https://sindresorhus.com'));
 	t.false(isUrl('https://sindresorhus.com abc'));
 	t.false(isUrl('https://sindresorhus.com/abc def'));
+	t.false(isUrl('//sindresorhus.com'));
+	t.false(isUrl('localhost'));
+	t.false(isUrl('192.168.0.1'));
+	t.false(isUrl('www.example.com'));
+});
+
+test('explicitly non-lenient', t => {
+	t.true(isUrl('https://sindresorhus.com', {lenient: false}));
+	t.true(isUrl('  https://sindresorhus.com  ', {lenient: false}));
+	t.false(isUrl('abc https://sindresorhus.com', {lenient: false}));
+	t.false(isUrl('https://sindresorhus.com abc', {lenient: false}));
+	t.false(isUrl('https://sindresorhus.com/abc def', {lenient: false}));
+	t.false(isUrl('//sindresorhus.com', {lenient: false}));
+	t.false(isUrl('localhost', {lenient: false}));
+	t.false(isUrl('192.168.0.1', {lenient: false}));
+	t.false(isUrl('www.example.com', {lenient: false}));
+});
+
+test('explicitly lenient', t => {
+	t.true(isUrl('https://sindresorhus.com', {lenient: true}));
+	t.true(isUrl('  https://sindresorhus.com  ', {lenient: true}));
+	t.false(isUrl('abc https://sindresorhus.com', {lenient: true}));
+	t.false(isUrl('https://sindresorhus.com abc', {lenient: true}));
+	t.false(isUrl('https://sindresorhus.com/abc def', {lenient: true}));
+	t.true(isUrl('//sindresorhus.com', {lenient: true}));
+	t.true(isUrl('localhost', {lenient: true}));
+	t.true(isUrl('192.168.0.1', {lenient: true}));
+	t.true(isUrl('www.example.com', {lenient: true}));
 });

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('main', t => {
 	t.false(isUrl('www.example.com'));
 });
 
-test('explicitly lenient', t => {
+test('lenient option', t => {
 	t.true(isUrl('https://sindresorhus.com', {lenient: true}));
 	t.true(isUrl('  https://sindresorhus.com  ', {lenient: true}));
 	t.false(isUrl('abc https://sindresorhus.com', {lenient: true}));

--- a/test.js
+++ b/test.js
@@ -13,18 +13,6 @@ test('main', t => {
 	t.false(isUrl('www.example.com'));
 });
 
-test('explicitly non-lenient', t => {
-	t.true(isUrl('https://sindresorhus.com', {lenient: false}));
-	t.true(isUrl('  https://sindresorhus.com  ', {lenient: false}));
-	t.false(isUrl('abc https://sindresorhus.com', {lenient: false}));
-	t.false(isUrl('https://sindresorhus.com abc', {lenient: false}));
-	t.false(isUrl('https://sindresorhus.com/abc def', {lenient: false}));
-	t.false(isUrl('//sindresorhus.com', {lenient: false}));
-	t.false(isUrl('localhost', {lenient: false}));
-	t.false(isUrl('192.168.0.1', {lenient: false}));
-	t.false(isUrl('www.example.com', {lenient: false}));
-});
-
 test('explicitly lenient', t => {
 	t.true(isUrl('https://sindresorhus.com', {lenient: true}));
 	t.true(isUrl('  https://sindresorhus.com  ', {lenient: true}));


### PR DESCRIPTION
Fixes #11 in a bit different way of how it was being discussed.

Instead of using https://github.com/sindresorhus/prepend-http, it will first try `new URL(string)`, as usual, cause it already covers all valid cases. And only if it fails, it checks if lenient mode is enabled; if so, it checks if prepending the protocol makes the input a valid url.
This way we keep the logic simple and avoid adding a dependency to the package.

What do you think?